### PR TITLE
Considerar las palabras clave en la busqueda

### DIFF
--- a/src/main/java/model/CGP.java
+++ b/src/main/java/model/CGP.java
@@ -52,9 +52,9 @@ public class CGP extends PuntoDeInteres {
 
     @Override
     protected boolean tienePalabra(final String palabra) {
-        boolean condicion1 = serviciosTienenPalabra(palabra);
-        boolean condicion2 = this.esPalabraClave(palabra);
-        return (condicion1 || condicion2);
+        boolean servicioTienePalabra = serviciosTienenPalabra(palabra);
+        boolean esPalabraClave = this.esPalabraClave(palabra);
+        return (servicioTienePalabra || esPalabraClave);
     }
     
     private boolean serviciosTienenPalabra(final String palabra){

--- a/src/main/java/model/CGP.java
+++ b/src/main/java/model/CGP.java
@@ -52,6 +52,12 @@ public class CGP extends PuntoDeInteres {
 
     @Override
     protected boolean tienePalabra(final String palabra) {
+        boolean condicion1 = serviciosTienenPalabra(palabra);
+        boolean condicion2 = this.esPalabraClave(palabra);
+        return (condicion1 || condicion2);
+    }
+    
+    private boolean serviciosTienenPalabra(final String palabra){
         for (ServicioCGP servicio : servicios) {
             if (servicio.getNombre().toLowerCase().contains(palabra.toLowerCase())) {
                 return true;

--- a/src/main/java/model/LocalComercial.java
+++ b/src/main/java/model/LocalComercial.java
@@ -52,11 +52,11 @@ public class LocalComercial extends PuntoDeInteres {
 
 	@Override
 	protected boolean tienePalabra(final String palabra) {
-		boolean condicion1 = nombre.toLowerCase().contains(palabra.toLowerCase());
-		boolean condicion2 = rubro.getNombre().toLowerCase().contains(palabra.toLowerCase());
-		boolean condicion3 = this.esPalabraClave(palabra);
+		boolean nombreTienePalabra = nombre.toLowerCase().contains(palabra.toLowerCase());
+		boolean rubroTienePalabra = rubro.getNombre().toLowerCase().contains(palabra.toLowerCase());
+		boolean esPalabraClave = this.esPalabraClave(palabra);
 
-		return (condicion1 || condicion2 || condicion3);
+		return (nombreTienePalabra || rubroTienePalabra || esPalabraClave);
 	}
 
 }

--- a/src/main/java/model/LocalComercial.java
+++ b/src/main/java/model/LocalComercial.java
@@ -54,8 +54,9 @@ public class LocalComercial extends PuntoDeInteres {
 	protected boolean tienePalabra(final String palabra) {
 		boolean condicion1 = nombre.toLowerCase().contains(palabra.toLowerCase());
 		boolean condicion2 = rubro.getNombre().toLowerCase().contains(palabra.toLowerCase());
+		boolean condicion3 = this.esPalabraClave(palabra);
 
-		return (condicion1 || condicion2);
+		return (condicion1 || condicion2 || condicion3);
 	}
 
 }

--- a/src/main/java/model/ParadaColectivo.java
+++ b/src/main/java/model/ParadaColectivo.java
@@ -24,9 +24,9 @@ public class ParadaColectivo extends PuntoDeInteres {
 
     @Override
     protected boolean tienePalabra(final String palabra) {
-        boolean condicion1 = linea.contains(palabra);
-        boolean condicion2 = this.esPalabraClave(palabra);
-        return (condicion1 || condicion2);
+        boolean lineaTienePalabra = linea.contains(palabra);
+        boolean esPalabraClave = this.esPalabraClave(palabra);
+        return (lineaTienePalabra || esPalabraClave);
     }
 
 }

--- a/src/main/java/model/ParadaColectivo.java
+++ b/src/main/java/model/ParadaColectivo.java
@@ -24,7 +24,9 @@ public class ParadaColectivo extends PuntoDeInteres {
 
     @Override
     protected boolean tienePalabra(final String palabra) {
-        return linea.contains(palabra);
+        boolean condicion1 = linea.contains(palabra);
+        boolean condicion2 = this.esPalabraClave(palabra);
+        return (condicion1 || condicion2);
     }
 
 }

--- a/src/main/java/model/PuntoDeInteres.java
+++ b/src/main/java/model/PuntoDeInteres.java
@@ -1,9 +1,14 @@
 package model;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public abstract class PuntoDeInteres {
 
     protected Direccion direccion;
     protected Geolocalizacion geolocalizacion;
+    protected ArrayList<String> palabrasClave;
 
     public Direccion getDireccion() {
         return direccion;
@@ -28,5 +33,20 @@ public abstract class PuntoDeInteres {
     }
 
     protected abstract boolean tienePalabra(final String palabra);
+    
+    public void setPalabrasClave(ArrayList<String> palabrasClave){
+        this.palabrasClave = palabrasClave;
+    }
+    
+    public ArrayList<String> getPalabrasClave(){
+        return this.palabrasClave;
+    }
+    
+    protected boolean esPalabraClave(final String palabra){
+        List<String> result = getPalabrasClave().stream()
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
+        return result.contains(palabra.toLowerCase());
+    }
 
 }

--- a/src/main/java/model/SucursalBanco.java
+++ b/src/main/java/model/SucursalBanco.java
@@ -56,10 +56,10 @@ public class SucursalBanco extends PuntoDeInteres {
 
     @Override
     protected boolean tienePalabra(final String palabra) {
-        boolean condicion1 = this.getBanco().toLowerCase().contains(palabra.toLowerCase());
-        boolean condicion2 = serviciosTienenPalabra(palabra);
-        boolean condicion3 = this.esPalabraClave(palabra);
-        return (condicion1 || condicion2 || condicion3);
+        boolean bancoTienePalabra = this.getBanco().toLowerCase().contains(palabra.toLowerCase());
+        boolean servicioTienePalabra = serviciosTienenPalabra(palabra);
+        boolean esPalabraClave = this.esPalabraClave(palabra);
+        return (bancoTienePalabra || servicioTienePalabra || esPalabraClave);
     }
 
     private boolean serviciosTienenPalabra(final String palabra) {

--- a/src/main/java/model/SucursalBanco.java
+++ b/src/main/java/model/SucursalBanco.java
@@ -58,7 +58,8 @@ public class SucursalBanco extends PuntoDeInteres {
     protected boolean tienePalabra(final String palabra) {
         boolean condicion1 = this.getBanco().toLowerCase().contains(palabra.toLowerCase());
         boolean condicion2 = serviciosTienenPalabra(palabra);
-        return (condicion1 || condicion2);
+        boolean condicion3 = this.esPalabraClave(palabra);
+        return (condicion1 || condicion2 || condicion3);
     }
 
     private boolean serviciosTienenPalabra(final String palabra) {

--- a/src/test/java/model/CGPTest.java
+++ b/src/test/java/model/CGPTest.java
@@ -37,6 +37,10 @@ public class CGPTest {
         servicios.add(servicioRentas);
         cgp.setServicios(servicios);
         
+        ArrayList<String> palabras = new ArrayList<String>();
+        palabras.add("CGP");
+        cgp.setPalabrasClave(palabras);
+        
         
     }
 
@@ -58,12 +62,17 @@ public class CGPTest {
     }
     
     @Test
-    public void tienePalabraServicioTest() {
+    public void tienePalabraCoincideServicio() {
         Assert.assertTrue(cgp.tienePalabra("rentas"));
     }
     
     @Test
-    public void noTienePalabraTest() {
+    public void tienePalabraCoincidePalabraClave() {
+        Assert.assertTrue(cgp.tienePalabra("cgp"));
+    }
+    
+    @Test
+    public void noTienePalabraCualquiera() {
         Assert.assertFalse(cgp.tienePalabra("futbol"));
     }
 

--- a/src/test/java/model/CGPTest.java
+++ b/src/test/java/model/CGPTest.java
@@ -50,29 +50,29 @@ public class CGPTest {
 
     
     @Test
-    public void noEsCercanoTest() {
+    public void dadaUnaGeolocalizacionFueraDelRangoDebeDevolverFalse() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(15, 15);
         Assert.assertFalse(cgp.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void esCercanoTest() {
+    public void dadaUnaGeolocalizacionDentroDelRangoDebeDevolverTrue() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(8, 8);
         Assert.assertTrue(cgp.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void tienePalabraCoincideServicio() {
+    public void dadaUnaPalabraCoincidenteConUnServicioDebeDevolverTrue() {
         Assert.assertTrue(cgp.tienePalabra("rentas"));
     }
     
     @Test
-    public void tienePalabraCoincidePalabraClave() {
+    public void dadaUnaPalabraIncluidaEnPalabrasClaveDebeDevolverTrue() {
         Assert.assertTrue(cgp.tienePalabra("cgp"));
     }
     
     @Test
-    public void noTienePalabraCualquiera() {
+    public void dadaUnaPalabraCualquieraDebeDevolverFalse() {
         Assert.assertFalse(cgp.tienePalabra("futbol"));
     }
 

--- a/src/test/java/model/CGPTest.java
+++ b/src/test/java/model/CGPTest.java
@@ -50,29 +50,29 @@ public class CGPTest {
 
     
     @Test
-    public void dadaUnaGeolocalizacionFueraDelRangoDebeDevolverFalse() {
+    public void dadaUnaGeolocalizacionFueraDelRangoEsCercanoDebeDevolverFalse() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(15, 15);
         Assert.assertFalse(cgp.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void dadaUnaGeolocalizacionDentroDelRangoDebeDevolverTrue() {
+    public void dadaUnaGeolocalizacionDentroDelRangoEsCercanoDebeDevolverTrue() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(8, 8);
         Assert.assertTrue(cgp.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void dadaUnaPalabraCoincidenteConUnServicioDebeDevolverTrue() {
+    public void dadaUnaPalabraCoincidenteConUnServicioTienePalabraDebeDevolverTrue() {
         Assert.assertTrue(cgp.tienePalabra("rentas"));
     }
     
     @Test
-    public void dadaUnaPalabraIncluidaEnPalabrasClaveDebeDevolverTrue() {
+    public void dadaUnaPalabraIncluidaEnPalabrasClaveTienePalabraDebeDevolverTrue() {
         Assert.assertTrue(cgp.tienePalabra("cgp"));
     }
     
     @Test
-    public void dadaUnaPalabraCualquieraDebeDevolverFalse() {
+    public void dadaUnaPalabraCualquieraTienePalabraDebeDevolverFalse() {
         Assert.assertFalse(cgp.tienePalabra("futbol"));
     }
 

--- a/src/test/java/model/LocalComercialTest.java
+++ b/src/test/java/model/LocalComercialTest.java
@@ -11,104 +11,105 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class LocalComercialTest {
-	private Horarios horarios;
-	private LocalComercial local;
-	private Rubro rubroLibreria;
-	private Geolocalizacion geolocalizacionLocal;
 
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
+    private Horarios horarios;
+    private LocalComercial local;
+    private Rubro rubroLibreria;
+    private Geolocalizacion geolocalizacionLocal;
 
-	}
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
 
-	@AfterClass
-	public static void tearDownAfterClass() throws Exception {
-	}
+    }
 
-	@Before
-	public void setUp() throws Exception {
-		//setUp para estaDisponible
-		horarios = new Horarios();
-		local = new LocalComercial();
-		local.setHorarios(horarios);
-		LocalTime horaInicioLunesAViernes = new LocalTime(9, 0);
-		LocalTime horaFinLunesAViernes = new LocalTime(13, 0);
-		LocalTime horaInicioLunesAViernes2 = new LocalTime(15, 0);
-		LocalTime horaFinLunesAViernes2 = new LocalTime(18, 30);
-		LocalTime horaInicioSabado = new LocalTime(10, 0);
-		LocalTime horaFinSabado = new LocalTime(13, 30);
-		RangoHorario manianaLunesAViernes = new RangoHorario(horaInicioLunesAViernes, horaFinLunesAViernes);
-		RangoHorario tardeLunesAViernes = new RangoHorario(horaInicioLunesAViernes2, horaFinLunesAViernes2);
-		RangoHorario horarioSabado = new RangoHorario(horaInicioSabado, horaFinSabado);
-		local.agregarRangoHorario(1, manianaLunesAViernes);
-		local.agregarRangoHorario(2, manianaLunesAViernes);
-		local.agregarRangoHorario(3, manianaLunesAViernes);
-		local.agregarRangoHorario(4, manianaLunesAViernes);
-		local.agregarRangoHorario(5, manianaLunesAViernes);
-		local.agregarRangoHorario(1, tardeLunesAViernes);
-		local.agregarRangoHorario(2, tardeLunesAViernes);
-		local.agregarRangoHorario(3, tardeLunesAViernes);
-		local.agregarRangoHorario(4, tardeLunesAViernes);
-		local.agregarRangoHorario(5, tardeLunesAViernes);
-		local.agregarRangoHorario(6, horarioSabado);
-		//setUp para esCercano
-		rubroLibreria = new Rubro();
-		geolocalizacionLocal = new Geolocalizacion(12, 28);
-		rubroLibreria.setNombre("Libreria Escolar");
-		rubroLibreria.setRadioCercania(5);
-		local.setRubro(rubroLibreria);
-		local.setGeolocalizacion(geolocalizacionLocal);
-		//setUp para tienePalabra()
-		local.setNombre("Regla y compás");
-		
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        //setUp para estaDisponible
+        horarios = new Horarios();
+        local = new LocalComercial();
+        local.setHorarios(horarios);
+        LocalTime horaInicioLunesAViernes = new LocalTime(9, 0);
+        LocalTime horaFinLunesAViernes = new LocalTime(13, 0);
+        LocalTime horaInicioLunesAViernes2 = new LocalTime(15, 0);
+        LocalTime horaFinLunesAViernes2 = new LocalTime(18, 30);
+        LocalTime horaInicioSabado = new LocalTime(10, 0);
+        LocalTime horaFinSabado = new LocalTime(13, 30);
+        RangoHorario manianaLunesAViernes = new RangoHorario(horaInicioLunesAViernes, horaFinLunesAViernes);
+        RangoHorario tardeLunesAViernes = new RangoHorario(horaInicioLunesAViernes2, horaFinLunesAViernes2);
+        RangoHorario horarioSabado = new RangoHorario(horaInicioSabado, horaFinSabado);
+        local.agregarRangoHorario(1, manianaLunesAViernes);
+        local.agregarRangoHorario(2, manianaLunesAViernes);
+        local.agregarRangoHorario(3, manianaLunesAViernes);
+        local.agregarRangoHorario(4, manianaLunesAViernes);
+        local.agregarRangoHorario(5, manianaLunesAViernes);
+        local.agregarRangoHorario(1, tardeLunesAViernes);
+        local.agregarRangoHorario(2, tardeLunesAViernes);
+        local.agregarRangoHorario(3, tardeLunesAViernes);
+        local.agregarRangoHorario(4, tardeLunesAViernes);
+        local.agregarRangoHorario(5, tardeLunesAViernes);
+        local.agregarRangoHorario(6, horarioSabado);
+        //setUp para esCercano
+        rubroLibreria = new Rubro();
+        geolocalizacionLocal = new Geolocalizacion(12, 28);
+        rubroLibreria.setNombre("Libreria Escolar");
+        rubroLibreria.setRadioCercania(5);
+        local.setRubro(rubroLibreria);
+        local.setGeolocalizacion(geolocalizacionLocal);
+        //setUp para tienePalabra()
+        local.setNombre("Regla y compás");
+
         ArrayList<String> palabras = new ArrayList<String>();
         palabras.add("Negocio");
         local.setPalabrasClave(palabras);
-	}
+    }
 
-	@After
-	public void tearDown() throws Exception {
-	}
+    @After
+    public void tearDown() throws Exception {
+    }
 
-	// TODO: Test no deterministico. Depende de la hora del dia en que lo
-	// ejecute. Ver de implementar Inversion of Control (IoC) para desacoplar.
-	// Hacer el refactor de la clase y luego terminar los tests para estaDisponible().
-	@Test
-	public void noEstaDisponibleSiendoViernesUnaTreintaTest() {
-		Assert.assertFalse(this.local.estaDisponible());
-	}
+    // TODO: Test no deterministico. Depende de la hora del dia en que lo
+    // ejecute. Ver de implementar Inversion of Control (IoC) para desacoplar.
+    // Hacer el refactor de la clase y luego terminar los tests para estaDisponible().
+    @Test
+    public void noEstaDisponibleSiendoViernesUnaTreintaTest() {
+        Assert.assertFalse(this.local.estaDisponible());
+    }
 
-	//Da alrededor de 3000 cuadras de distancia. No es Cercano.
-	@Test
-	public void noEsCercanoLibreriaEscolarTest() {
-		Geolocalizacion unaGeolocalizacion = new Geolocalizacion(11, 30);
-		Assert.assertFalse(local.esCercano(unaGeolocalizacion));
-	}
-	
-	@Test
-	public void esCercanoLibreriaEscolarTest() {
-		Geolocalizacion unaGeolocalizacion = new Geolocalizacion(11.999991, 28.000001);
-		Assert.assertTrue(local.esCercano(unaGeolocalizacion));
-	}
-	
-	@Test
-	public void tienePalabraCoincideNombreLocal() {
-		Assert.assertTrue(local.tienePalabra("reGla"));
-	}
-	
-	@Test
-	public void tienePalabraCoincideNombreRubro() {
-		Assert.assertTrue(local.tienePalabra("breRIA"));
-	}
-	
-	   @Test
-	    public void tienePalabraCoincidePalabraClave() {
-	        Assert.assertTrue(local.tienePalabra("negocio"));
-	    }
-	
-	@Test
-	public void noTienePalabra() {
-		Assert.assertFalse(local.tienePalabra("futbol"));
-	}
+    //Da alrededor de 3000 cuadras de distancia. No es Cercano.
+    @Test
+    public void dadaUnaGeolocalizacionFueraDelRangoDebeDevolverFalse() {
+        Geolocalizacion unaGeolocalizacion = new Geolocalizacion(11, 30);
+        Assert.assertFalse(local.esCercano(unaGeolocalizacion));
+    }
+
+    @Test
+    public void dadaUnaGeolocalizacionDentroDelRangoDebeDevolverFalse() {
+        Geolocalizacion unaGeolocalizacion = new Geolocalizacion(11.999991, 28.000001);
+        Assert.assertTrue(local.esCercano(unaGeolocalizacion));
+    }
+
+    @Test
+    public void dadaPalabraCoincidenteConNombreDelLocalDebeDevolverTrue() {
+        Assert.assertTrue(local.tienePalabra("reGla"));
+    }
+
+    @Test
+    public void dadaPalabraCoincidenteConElRubroDebeDevolverTrue() {
+        Assert.assertTrue(local.tienePalabra("breRIA"));
+    }
+
+    @Test
+    public void dadaUnaPalabraIncluidaEnPalabrasClaveDebeDevolverTrue() {
+        Assert.assertTrue(local.tienePalabra("negocio"));
+    }
+
+    @Test
+    public void dadaUnaPalabraCualquieraDebeDevolverFalse() {
+        Assert.assertFalse(local.tienePalabra("futbol"));
+    }
 
 }

--- a/src/test/java/model/LocalComercialTest.java
+++ b/src/test/java/model/LocalComercialTest.java
@@ -81,13 +81,13 @@ public class LocalComercialTest {
 
     //Da alrededor de 3000 cuadras de distancia. No es Cercano.
     @Test
-    public void dadaUnaGeolocalizacionFueraDelRangoDebeDevolverFalse() {
+    public void dadaUnaGeolocalizacionFueraDelRangoEsCercanoDebeDevolverFalse() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(11, 30);
         Assert.assertFalse(local.esCercano(unaGeolocalizacion));
     }
 
     @Test
-    public void dadaUnaGeolocalizacionDentroDelRangoDebeDevolverFalse() {
+    public void dadaUnaGeolocalizacionDentroDelRangoEsCercanoDebeDevolverFalse() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(11.999991, 28.000001);
         Assert.assertTrue(local.esCercano(unaGeolocalizacion));
     }
@@ -98,17 +98,17 @@ public class LocalComercialTest {
     }
 
     @Test
-    public void dadaPalabraCoincidenteConElRubroDebeDevolverTrue() {
+    public void dadaPalabraCoincidenteConElRubroTienePalabraDebeDevolverTrue() {
         Assert.assertTrue(local.tienePalabra("breRIA"));
     }
 
     @Test
-    public void dadaUnaPalabraIncluidaEnPalabrasClaveDebeDevolverTrue() {
+    public void dadaUnaPalabraIncluidaEnPalabrasClaveTienePalabraDebeDevolverTrue() {
         Assert.assertTrue(local.tienePalabra("negocio"));
     }
 
     @Test
-    public void dadaUnaPalabraCualquieraDebeDevolverFalse() {
+    public void dadaUnaPalabraCualquieraTienePalabraDebeDevolverFalse() {
         Assert.assertFalse(local.tienePalabra("futbol"));
     }
 

--- a/src/test/java/model/LocalComercialTest.java
+++ b/src/test/java/model/LocalComercialTest.java
@@ -1,5 +1,7 @@
 package model;
 
+import java.util.ArrayList;
+
 import org.joda.time.LocalTime;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -58,6 +60,10 @@ public class LocalComercialTest {
 		local.setGeolocalizacion(geolocalizacionLocal);
 		//setUp para tienePalabra()
 		local.setNombre("Regla y compás");
+		
+        ArrayList<String> palabras = new ArrayList<String>();
+        palabras.add("Negocio");
+        local.setPalabrasClave(palabras);
 	}
 
 	@After
@@ -94,6 +100,11 @@ public class LocalComercialTest {
 	public void tienePalabraCoincideNombreRubro() {
 		Assert.assertTrue(local.tienePalabra("breRIA"));
 	}
+	
+	   @Test
+	    public void tienePalabraCoincidePalabraClave() {
+	        Assert.assertTrue(local.tienePalabra("negocio"));
+	    }
 	
 	@Test
 	public void noTienePalabra() {

--- a/src/test/java/model/ParadaColectivoTest.java
+++ b/src/test/java/model/ParadaColectivoTest.java
@@ -1,5 +1,7 @@
 package model;
 
+import java.util.ArrayList;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -26,6 +28,9 @@ public class ParadaColectivoTest {
         //setUp
         parada = new ParadaColectivo();
         parada.setLinea("103");
+        ArrayList<String> palabras = new ArrayList<String>();
+        palabras.add("Colectivo");
+        parada.setPalabrasClave(palabras);
         geolocalizacionParada = new Geolocalizacion(12, 28);
         parada.setGeolocalizacion(geolocalizacionParada);
     }
@@ -47,13 +52,17 @@ public class ParadaColectivoTest {
     }
     
     @Test
-    public void tienePalabra() {
+    public void tienePalabraIgualASuLinea() {
         Assert.assertTrue(parada.tienePalabra("103"));
     }
     
     @Test
-    public void noTienePalabra() {
+    public void tienePalabraPalabraClave() {
+        Assert.assertTrue(parada.tienePalabra("Colectivo"));
+    }
+    
+    @Test
+    public void noTienePalabraCualquiera() {
         Assert.assertFalse(parada.tienePalabra("132"));
     }
-
 }

--- a/src/test/java/model/ParadaColectivoTest.java
+++ b/src/test/java/model/ParadaColectivoTest.java
@@ -40,19 +40,19 @@ public class ParadaColectivoTest {
     }
 
     @Test
-    public void dadaUnaGeolocalizacionFueraDelRangoDebeDevolverFalse() {
+    public void dadaUnaGeolocalizacionFueraDelRangoEsCercanoDebeDevolverFalse() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(12+1, 28+1);
         Assert.assertFalse(parada.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void  dadaUnaGeolocalizacionDentroDelRangoDebeDevolverTrue() {
+    public void  dadaUnaGeolocalizacionDentroDelRangoEsCercanoDebeDevolverTrue() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(12, 28);
         Assert.assertTrue(parada.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void dadaUnaPalabraIgualASuLineaDebeDevolverTrue() {
+    public void dadaUnaPalabraIgualASuLineaTienePalabraDebeDevolverTrue() {
         Assert.assertTrue(parada.tienePalabra("103"));
     }
     
@@ -62,7 +62,7 @@ public class ParadaColectivoTest {
     }
     
     @Test
-    public void dadaUnaPalabraCualquieraNoIncluidaEnNingunConjuntoDebeDevolverFalse() {
+    public void dadaUnaPalabraCualquieraNoIncluidaEnNingunConjuntoTienePalabraDebeDevolverFalse() {
         Assert.assertFalse(parada.tienePalabra("132"));
     }
 }

--- a/src/test/java/model/ParadaColectivoTest.java
+++ b/src/test/java/model/ParadaColectivoTest.java
@@ -57,7 +57,7 @@ public class ParadaColectivoTest {
     }
     
     @Test
-    public void tienePalabraPalabraClave() {
+    public void tienePalabraIgualAPalabraClave() {
         Assert.assertTrue(parada.tienePalabra("Colectivo"));
     }
     

--- a/src/test/java/model/ParadaColectivoTest.java
+++ b/src/test/java/model/ParadaColectivoTest.java
@@ -40,29 +40,29 @@ public class ParadaColectivoTest {
     }
 
     @Test
-    public void noEsCercanaParadaTest() {
+    public void dadaUnaGeolocalizacionFueraDelRangoDebeDevolverFalse() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(12+1, 28+1);
         Assert.assertFalse(parada.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void esCercanaParadaTest() {
+    public void  dadaUnaGeolocalizacionDentroDelRangoDebeDevolverTrue() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(12, 28);
         Assert.assertTrue(parada.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void tienePalabraIgualASuLinea() {
+    public void dadaUnaPalabraIgualASuLineaDebeDevolverTrue() {
         Assert.assertTrue(parada.tienePalabra("103"));
     }
     
     @Test
-    public void tienePalabraIgualAPalabraClave() {
+    public void dadaUnaPalabraClaveExistenteTienePalabraDebeDevolverTrue() {
         Assert.assertTrue(parada.tienePalabra("Colectivo"));
     }
     
     @Test
-    public void noTienePalabraCualquiera() {
+    public void dadaUnaPalabraCualquieraNoIncluidaEnNingunConjuntoDebeDevolverFalse() {
         Assert.assertFalse(parada.tienePalabra("132"));
     }
 }

--- a/src/test/java/model/SucursalBancoTest.java
+++ b/src/test/java/model/SucursalBancoTest.java
@@ -54,34 +54,34 @@ public class SucursalBancoTest {
 
     //Da alrededor de 3000 cuadras de distancia. No es Cercano.
     @Test
-    public void noEsCercanoTest() {
+    public void dadaUnaGeolocalizacionFueraDelRangoDebeDevolverFalse() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(11, 30);
         Assert.assertFalse(sucursal.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void esCercanoTest() {
+    public void dadaUnaGeolocalizacionDentroDelRangoDebeDevolverTrue() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(11.999991, 28.000001);
         Assert.assertTrue(sucursal.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void tienePalabraCoincideNombre() {
+    public void dadaUnaPalabraCoincidenteConElBancoDebeDevolverTrue() {
         Assert.assertTrue(sucursal.tienePalabra("nacion"));
     }
     
     @Test
-    public void tienePalabraCoincideServicio() {
+    public void dadaUnaPalabraCoincidenteConUnServicioDebeDevolverTrue() {
         Assert.assertTrue(sucursal.tienePalabra("asesoramiento"));
     }
     
     @Test
-    public void tienePalabraCoincidePalabraClave() {
+    public void dadaUnaPalabraIncluidaEnPalabrasClaveDebeDevolverTrue() {
         Assert.assertTrue(sucursal.tienePalabra("banco"));
     }
     
     @Test
-    public void noTienePalabra() {
+    public void dadaUnaPalabraCualquieraDebeDevolverFalse() {
         Assert.assertFalse(sucursal.tienePalabra("futbol"));
     }
 }

--- a/src/test/java/model/SucursalBancoTest.java
+++ b/src/test/java/model/SucursalBancoTest.java
@@ -54,34 +54,34 @@ public class SucursalBancoTest {
 
     //Da alrededor de 3000 cuadras de distancia. No es Cercano.
     @Test
-    public void dadaUnaGeolocalizacionFueraDelRangoDebeDevolverFalse() {
+    public void dadaUnaGeolocalizacionFueraDelRangoEsCercanoDebeDevolverFalse() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(11, 30);
         Assert.assertFalse(sucursal.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void dadaUnaGeolocalizacionDentroDelRangoDebeDevolverTrue() {
+    public void dadaUnaGeolocalizacionDentroDelRangoEsCercanoDebeDevolverTrue() {
         Geolocalizacion unaGeolocalizacion = new Geolocalizacion(11.999991, 28.000001);
         Assert.assertTrue(sucursal.esCercano(unaGeolocalizacion));
     }
     
     @Test
-    public void dadaUnaPalabraCoincidenteConElBancoDebeDevolverTrue() {
+    public void dadaUnaPalabraCoincidenteConElBancoTienePalabraDebeDevolverTrue() {
         Assert.assertTrue(sucursal.tienePalabra("nacion"));
     }
     
     @Test
-    public void dadaUnaPalabraCoincidenteConUnServicioDebeDevolverTrue() {
+    public void dadaUnaPalabraCoincidenteConUnServicioTienePalabraDebeDevolverTrue() {
         Assert.assertTrue(sucursal.tienePalabra("asesoramiento"));
     }
     
     @Test
-    public void dadaUnaPalabraIncluidaEnPalabrasClaveDebeDevolverTrue() {
+    public void dadaUnaPalabraIncluidaEnPalabrasClaveTienePalabraDebeDevolverTrue() {
         Assert.assertTrue(sucursal.tienePalabra("banco"));
     }
     
     @Test
-    public void dadaUnaPalabraCualquieraDebeDevolverFalse() {
+    public void dadaUnaPalabraCualquieraTienePalabraDebeDevolverFalse() {
         Assert.assertFalse(sucursal.tienePalabra("futbol"));
     }
 }

--- a/src/test/java/model/SucursalBancoTest.java
+++ b/src/test/java/model/SucursalBancoTest.java
@@ -42,6 +42,10 @@ public class SucursalBancoTest {
         horarioServicio.agregarRangoHorario(2, tardeLunesYMartes);
         servicio.setHorarios(horarioServicio);
         sucursal.setServicios(servicios);
+        
+        ArrayList<String> palabras = new ArrayList<String>();
+        palabras.add("Banco");
+        sucursal.setPalabrasClave(palabras);
     }
 
     @After
@@ -69,6 +73,11 @@ public class SucursalBancoTest {
     @Test
     public void tienePalabraCoincideServicio() {
         Assert.assertTrue(sucursal.tienePalabra("asesoramiento"));
+    }
+    
+    @Test
+    public void tienePalabraCoincidePalabraClave() {
+        Assert.assertTrue(sucursal.tienePalabra("banco"));
     }
     
     @Test

--- a/src/test/java/model/TerminalInteractivaTest.java
+++ b/src/test/java/model/TerminalInteractivaTest.java
@@ -24,6 +24,9 @@ public class TerminalInteractivaTest {
         ArrayList<PuntoDeInteres> pois = new ArrayList<PuntoDeInteres>();
         pois.add(local);
         terminal.setPuntosDeInteres(pois);
+        ArrayList<String> palabras = new ArrayList<String>();
+        palabras.add("Local");
+        local.setPalabrasClave(palabras);
     }
 
     @After
@@ -33,6 +36,11 @@ public class TerminalInteractivaTest {
     @Test
     public void BuscarYEncontrarPOIKiosco() {
         ArrayList<PuntoDeInteres> resultado = terminal.buscarPuntoDeInteres("kiosko");
+        Assert.assertTrue(resultado.contains(local));
+    }
+    
+    public void BuscarYEncontrarPOIKioscoPorPalabraClave() {
+        ArrayList<PuntoDeInteres> resultado = terminal.buscarPuntoDeInteres("loCal");
         Assert.assertTrue(resultado.contains(local));
     }
     


### PR DESCRIPTION
Dado el issue #6 
Agregué está función en PuntoDeInteres, ya que es general para todos los POI (por ahora), para que las demás subclases la utilicen como una condición extra dentro de lo que ya tenían implementando de tienePalabra()
```
protected ArrayList<String> palabrasClave;

    protected boolean esPalabraClave(final String palabra){
        List<String> result = getPalabrasClave().stream()
                .map(String::toLowerCase)
                .collect(Collectors.toList());
        return result.contains(palabra.toLowerCase());
    }
```
Ademas, añadí a cada test un caso de búsqueda de palabra clave 
